### PR TITLE
add logger and db wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+*.db
+*.log
+src/__pycache
+src/utils/__pycache

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,93 @@
+# MIT License
+
+# Copyright (c) 2018 ChickenTicket
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+__all__ = ["Ledger", "Wallet", "DB"]
+
+from utils.logger import get_logger
+
+from contextlib import contextmanager
+
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+logger = get_logger(level=0) # NOTSET: all messages
+
+Base = declarative_base()
+
+class Ledger(Base):
+    __tablename__ = "transactions"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    height = Column(Integer, nullable=False)
+    timestamp = Column(Integer, nullable=False)
+    address = Column(String(length=64), nullable=False)
+    recipient = Column(String(length=64), nullable=False)
+    amount = Column(Integer, nullable=False)
+    signature = Column(String, nullable=False)
+    public_key = Column(String(length=88), nullable=False)
+    block_hash = Column(String, nullable=False, unique=True)
+    fee = Column(Integer, nullable=False)
+    reward = Column(Integer, nullable=False)
+    openfield = Column(String, nullable=False)
+
+    def __repr__(self):
+        return "<Transaction(id={0.id}, height={0.height}, timestamp={0.timestamp}, address='{0.address}', recipient='{0.recipient}', amount={0.amount}, signature='{0.signature}', public_key='{0.public_key}', block_hash='{0.block_hash}', fee={0.fee}, reward={0.reward}, openfield='{0.openfield}')>".format(self)
+
+class Wallet(Base):
+    __tablename__ = "wallet"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    address = Column(String(length=64), nullable=False, unique=True)
+    public_key = Column(String(length=88), nullable=False, unique=True)
+    private_key = Column(String(length=64), nullable=False, unique=True)
+
+    def __repr__(self):
+        return "<Wallet(id={0.id}, address='{0.address}', public_key='{0.public_key}', private_key='{0.private_key}')>".format(self)
+
+# adapter class
+class DB:
+    def __init__(self, *args, **kwargs):
+        db_name = kwargs.get("db_name", "pychickenticket")
+        self.engine = create_engine("sqlite:///{}.db".format(db_name))
+        self.Session = sessionmaker(bind=self.engine)
+        Base.metadata.create_all(self.engine)
+
+    @contextmanager # allows to cleanly open and close sessions, automatically rolling back any errors
+    def get_session(self):
+        session = self.Session()
+        try:
+            yield session
+            session.commit()
+        except Exception as e:
+            logger.critical("{0.name}: {0!s}".format(e))
+            session.rollback()
+        finally:
+            session.close()
+
+# To use DB class elsewhere:
+#
+# from db import DB
+#
+# database = DB()
+# with DB.get_session() as session:
+#   session.query/insert...

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,0 +1,47 @@
+# MIT License
+
+# Copyright (c) 2018 ChickenTicket
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+__all__ = ['get_logger']
+
+import inspect
+import logging
+
+from logging import handlers
+
+FILE_HANDLER = handlers.RotatingFileHandler(filename="logs/pychickenticket.log", maxBytes=5 * 1024 * 1024, backupCount=3) # max 5Mb log files, with 3 past logs saved
+LOG_FORMATTER = logging.Formatter("%(asctime)s %(levelname)s | [In module %(module)s -> function %(funcName)s] (%(filename)s:%(lineno)s) | %(message)s")
+
+FILE_HANDLER.setLevel(logging.NOTSET) # handler logs all messages that make it past the logger
+FILE_HANDLER.setFormatter(LOG_FORMATTER)
+
+# special logger makes a new logger for each module (preferably create a new logger instance in each file)
+def get_logger(level=logging.WARNING):
+  # get calling module's name
+  call_frame = inspect.stack()[1]
+  call_module = inspect.getmodule(call_frame[0])
+  module_name = call_module.__name__
+
+  module_logger = logging.getLogger(module_name)
+  module_logger.setLevel(level)
+  module_logger.addHandler(FILE_HANDLER)
+
+  return module_logger


### PR DESCRIPTION
The db wrapper is mean to be used with the contextmanager, so a query example should look like
```py
db_wrapper = db.DB()

with db_wrapper.get_session() as sess:
    transactions = sess.query(db.Ledger).all()
```

The only requirements to use the logger wrapper is to import the `get_logger` function and call that at the top of the script file (do this in each file, preferably) and pass a `level=log_level` if you want a level besides `WARNING`.
After that, it functions like a normal logger object.

( also adds .gitignore, because we don't have one for some reason @Aareon )